### PR TITLE
Oodify group

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -42,10 +42,6 @@ $(document).ready( function() {
                                             // Add green background to user rows
                                             if (oSettings.aoData[i]._aData.username == JobStatusapp.username) {
                                                 oSettings.aoData[i].nTr.className += " bg-success";
-                                            // Add blue background to group rows
-                                            } else if (oSettings.aoData[i]._aData.group ==
-JobStatusapp.group) {
-                                                oSettings.aoData[i].nTr.className += " bg-info";
                                             }
                                         }
                                     },
@@ -72,11 +68,6 @@ JobStatusapp.group) {
                 data:               "username",
                 className:          "small",
                 width:              "4em"
-            },
-            {
-                data:               "group",
-                className:          "small",
-                "autoWidth":        true
             },
             {
                 data:               "status",
@@ -223,12 +214,10 @@ function is_defined( object ) {
 function build_job_information_panel( d ) {
     var _Job_Name = d.jobname;
     var _username = d.username;
-    var _group = d.group;
     var _walltime_requested = d.walltime;
     var _queue = d.queue;
     var _walltime_used = (is_defined(d.walltime_used) ? d.walltime_used : '0');
     return          label_data("Username", _username) +
-                    label_data("Group Name", _group) +
                     label_data("Walltime", _walltime_used + " / " + _walltime_requested) +
                     label_data("Queue", _queue);
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -80,9 +80,6 @@ class PagesController < ApplicationController
       if cookies[:jobfilter] == 'all'
         # Get all jobs
         result = b.get_jobs
-      elsif cookies[:jobfilter] == 'group'
-        # Get all group jobs
-        result = b.get_jobs.select { |id, attr| attr[:egroup] == get_usergroup }
       else
         # Get all user jobs
         result = b.get_jobs.select { |id, attr| attr[:Job_Owner] =~ /^#{get_username}@/ }
@@ -100,9 +97,9 @@ class PagesController < ApplicationController
       end
     end
 
-    # Sort jobs by username, then group
+    # Sort user's jobs to the top
     jobs.sort_by! do |user|
-      user.username == get_username ? 0 : user.group == get_usergroup ? 1 : 2
+      user.username == get_username ? 0 : 1
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,10 +4,6 @@ module ApplicationHelper
     ENV['USER']
   end
 
-  def get_usergroup
-    Etc.getgrgid(Process.gid).name
-  end
-
   def get_remoteuser
     ENV['REMOTE_USER']
   end

--- a/app/models/jobstatusdata.rb
+++ b/app/models/jobstatusdata.rb
@@ -7,7 +7,7 @@
 # @version 0.0.1
 class Jobstatusdata
 
-  attr_reader :pbsid, :jobname, :username, :group, :status, :cluster, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :terminal_path, :fs_path
+  attr_reader :pbsid, :jobname, :username, :status, :cluster, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :terminal_path, :fs_path
 
   # Define an object containing only necessary data to send to client.
   #
@@ -18,7 +18,6 @@ class Jobstatusdata
     self.pbsid = pbs_job[:name]
     self.jobname = pbs_job[:attribs][:Job_Name]
     self.username = username_format(pbs_job[:attribs][:Job_Owner])
-    self.group = pbs_job[:attribs][:Account_Name].blank? ? Etc.getgrgid(Etc.getpwnam(self.username).gid).name : pbs_job[:attribs][:Account_Name]
     self.status = pbs_job[:attribs][:job_state]
     if self.status == "R" || self.status == "C"
       self.nodes = node_array(pbs_job[:attribs][:exec_host])
@@ -78,6 +77,6 @@ class Jobstatusdata
     attribs_Job_Owner.split('@')[0]
   end
 
-    attr_writer :pbsid, :jobname, :username, :group, :status, :cluster, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :terminal_path, :fs_path
+    attr_writer :pbsid, :jobname, :username, :status, :cluster, :nodes, :starttime, :walltime, :walltime_used, :submit_args, :output_path, :nodect, :ppn, :total_cpu, :queue, :cput, :mem, :vmem, :terminal_path, :fs_path
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,6 @@
       var JobStatusapp = {
         user:     "<%= get_remoteuser %>",
         app:      "<%= ENV['APP_TOKEN'] %>",
-        group:    "<%= get_usergroup %>",
         username: "<%= get_username %>"
       };
     </script>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -2,9 +2,6 @@
     <label class="btn btn-primary  <%= (cookies[:jobfilter] == 'user') || (!cookies[:jobfilter]) ? 'active' : '' %>" onclick="docCookies.setItem('jobfilter', 'user'); window.location.reload();" >
         <input type="radio" name="user" id="option_user" > Your Jobs
     </label>
-    <label class="btn btn-primary <%= cookies[:jobfilter] == 'group' ? 'active' : '' %>" onclick="docCookies.setItem('jobfilter', 'group'); window.location.reload();">
-        <input type="radio" name="group" id="option_group" > Your Group's Jobs (<%= get_usergroup %>)
-    </label>
     <label class="btn btn-primary <%= cookies[:jobfilter] == 'all' ? 'active' : '' %>" onclick="docCookies.setItem('jobfilter', 'all'); window.location.reload();">
         <input type="radio" name="all" id="option_all" > All Jobs
     </label>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -16,7 +16,6 @@
                     <th>ID</th>
                     <th>Name</th>
                     <th>User</th>
-                    <th>Group</th>
                     <th>Status</th>
                     <th>Cluster</th>
                 </tr>


### PR DESCRIPTION
This removes the system group requirement from the app for use on systems without that functionality.

After committing this, I think that this is actually a very aggressive cut. Maybe too aggressive.

We can actually probably leave the group in the views. On systems where group isn't available a blank string is send to the frontend and there would then just be a blank space under the column.

I think that users not having a primary linux group may be an edge case and we're losing that functionality for something that might happen.

--- 

My other concern with this is that I'm not happy with the `.sort_by!` method in the controller, the priority sort should be updated to sort by username after bubbling the current user to the top of the stack. I can revisit that when I get another moment.